### PR TITLE
fix: don't require siteUrl when host and sitemap are set

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,6 @@ module.exports = {
 };
 ```
 
-
 ## License
+
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fmdreizin%2Fgatsby-plugin-robots-txt.svg?type=large)](https://app.fossa.io/projects/git%2Bgithub.com%2Fmdreizin%2Fgatsby-plugin-robots-txt?ref=badge_large)


### PR DESCRIPTION
While the case of siteUrl not beeing present was handled, the code didn't
actually run because the graphql client emits an error when a non present
field is queried. This changes the behaviour so that a query is only
executed when either host or sitemap aren't set.

The change should be non-breaking.