### PR TITLE
fix env option merge and update test

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -48,7 +48,7 @@ const getOptions = pluginOptions => {
   delete options.env;
   delete options.resolveEnv;
 
-  return { ...options, envOptions };
+  return { ...options, ...envOptions };
 };
 
 export async function onPostBuild({ graphql }, pluginOptions) {

--- a/test/__snapshots__/gatsby-node.test.js.snap
+++ b/test/__snapshots__/gatsby-node.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`onPostBuild should generate \`robots.txt\` using \`env\` options 1`] = `
 "User-agent: *
-Allow: /
+Disallow: /
 Sitemap: https://www.test.com/sitemap.xml
 Host: https://www.test.com
 "
@@ -10,7 +10,7 @@ Host: https://www.test.com
 
 exports[`onPostBuild should generate \`robots.txt\` using \`env\` options and \`resolveEnv\` function 1`] = `
 "User-agent: *
-Allow: /
+Disallow: /
 Sitemap: https://www.test.com/sitemap.xml
 Host: https://www.test.com
 "


### PR DESCRIPTION
Env options weren't being merged correctly, which resulted in an options object that looked like: `{ envOptions: {..}}`

The jest test asked to make a policy like `{ userAgent: '*', disallow: ['/'] }` but the snapshot had a policy like:
```
User-agent: *
Allow: /
```