### PR TITLE
feat: configurable query for site URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,30 @@ module.exports = {
 };
 ```
 
+### Query
+By default the site URL will come from the Gatsby node `site.siteMeta.siteUrl`. Like in [Gatsby's sitemap plugin](https://www.gatsbyjs.org/packages/gatsby-plugin-sitemap/) an optional GraphQL query can be used to provide a different value from another data source as long as it returns the same shape:
+
+`gatsby-config.js`
+
+```js
+module.exports = {
+  plugins: [
+    {
+      resolve: 'gatsby-plugin-robots-txt',
+      options: {
+        query: {
+          site: MyCustomDataSource {
+            siteMetadata {
+              siteUrl
+            }
+          }
+        }
+      }
+    }
+  ]
+};
+```
+
 ## License
 
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fmdreizin%2Fgatsby-plugin-robots-txt.svg?type=large)](https://app.fossa.io/projects/git%2Bgithub.com%2Fmdreizin%2Fgatsby-plugin-robots-txt?ref=badge_large)

--- a/README.md
+++ b/README.md
@@ -205,13 +205,13 @@ module.exports = {
     {
       resolve: 'gatsby-plugin-robots-txt',
       options: {
-        query: {
+        query: `{
           site: MyCustomDataSource {
             siteMetadata {
               siteUrl
             }
           }
-        }
+        }`
       }
     }
   ]

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -4,15 +4,17 @@ import path from 'path';
 import url from 'url';
 
 const publicPath = './public';
-const query = `{
-  site {
-    siteMetadata {
-      siteUrl
-    }
-  }
-}
-`;
 const defaultEnv = 'development';
+const defaultOptions = {
+  output: '/robots.txt',
+  query: `{
+    site {
+      siteMetadata {
+        siteUrl
+      }
+    }
+  }`
+};
 
 function writeFile(file, data) {
   return new Promise((resolve, reject) => {
@@ -53,11 +55,6 @@ const getOptions = pluginOptions => {
 
 export async function onPostBuild({ graphql }, pluginOptions) {
   const userOptions = getOptions(pluginOptions);
-
-  const defaultOptions = {
-    output: '/robots.txt'
-  };
-
   const mergedOptions = { ...defaultOptions, ...userOptions };
 
   if (
@@ -68,7 +65,7 @@ export async function onPostBuild({ graphql }, pluginOptions) {
       site: {
         siteMetadata: { siteUrl }
       }
-    } = await runQuery(graphql, query);
+    } = await runQuery(graphql, mergedOptions.query);
 
     mergedOptions.host = siteUrl;
     mergedOptions.sitemap = url.resolve(siteUrl, 'sitemap.xml');


### PR DESCRIPTION
The core Gatsby sitemap plugin allows for Configurable queries to get the siteUrl. See: https://www.gatsbyjs.org/packages/gatsby-plugin-sitemap

This is necessary because when using Gatsby to generate sites with dynamic URLs, you can't dynamically set the siteMetadata from a data source.

This PR adds the same capability to the robots.txt plugin so that it can behave consistently. If sitemap.xml is using a different domain, then robots.txt should be able to as well.
