### PR TITLE
read from GATSBY_ACTIVE_ENV by default

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -43,7 +43,7 @@ const getOptions = pluginOptions => {
 
   delete options.plugins;
 
-  const { env = {}, resolveEnv = () => process.env.NODE_ENV } = options;
+  const { env = {}, resolveEnv = () => process.env.GATSBY_ACTIVE_ENV || process.env.NODE_ENV } = options;
 
   const envOptions = env[resolveEnv()] || env[defaultEnv] || {};
 


### PR DESCRIPTION
https://www.gatsbyjs.org/docs/environment-variables/

GATSBY_ACTIVE_ENV is a quite new env variable, not very well documented imho. Setting it to staging will make gatsby read from .env.staging file for example