### PR TITLE
fixes #85 : No support for multiple sitemaps?

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This plugin uses [`generate-robotstxt`](https://github.com/itgalaxy/generate-rob
 |     Name     |    Type    |                Default                |                                  Description                                   |
 | :----------: | :--------: | :-----------------------------------: | :----------------------------------------------------------------------------: |
 |    `host`    |  `String`  |       `${siteMetadata.siteUrl}`       |                               Host of your site                                |
-|  `sitemap`   |  `String`  | `${siteMetadata.siteUrl}/sitemap.xml` |                             Path to `sitemap.xml`                              |
+|  `sitemap`   |  `String` / `String[]`  | `${siteMetadata.siteUrl}/sitemap.xml` |                             Path(s) to `sitemap.xml`                              |
 |   `policy`   | `Policy[]` |                 `[]`                  | List of [`Policy`](https://github.com/itgalaxy/generate-robotstxt#usage) rules |
 | `configFile` |  `String`  |              `undefined`              |                          Path to external config file                          |
 |   `output`   |  `String`  |             `/robots.txt`             |                     Path where to create the `robots.txt`                      |


### PR DESCRIPTION
prop value of `sitemap` changed from string to string array.
fixes issue https://github.com/mdreizin/gatsby-plugin-robots-txt/issues/85