### PR TITLE
add src file to npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "gatsby-plugin-robots-txt",
   "files": [
-    "gatsby-*.js*"
+    "gatsby-*.js*",
+    "src/gatsby-node.js"
   ],
   "main": "index.js",
   "description": "Gatsby plugin that automatically creates robots.txt for your site",

--- a/package.json
+++ b/package.json
@@ -50,5 +50,6 @@
   },
   "jest": {
     "collectCoverage": true
-  }
+  },
+  "version": "1.5.2"
 }

--- a/package.json
+++ b/package.json
@@ -50,6 +50,5 @@
   },
   "jest": {
     "collectCoverage": true
-  },
-  "version": "1.5.2"
+  }
 }


### PR DESCRIPTION
Fixes #273 
Source file is missing in NPM package which causes as error since the file is referenced in gatsby-node.js.map file