### PR TITLE
Fix: several sitemap related issues

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -52,7 +52,7 @@ const getOptions = pluginOptions => {
   return { ...options, ...envOptions };
 };
 
-export async function onPostBuild({ graphql }, pluginOptions) {
+export async function onPostBuild({ graphql, pathPrefix = "" }, pluginOptions) {
   const userOptions = getOptions(pluginOptions);
   const mergedOptions = { ...defaultOptions, ...userOptions };
 
@@ -71,12 +71,13 @@ export async function onPostBuild({ graphql }, pluginOptions) {
   if (
     !Object.prototype.hasOwnProperty.call(mergedOptions, 'sitemap')
   ) {
-    mergedOptions.sitemap = new URL('sitemap-index.xml', mergedOptions.host).toString();
+
+    mergedOptions.sitemap = new URL(path.posix.join(pathPrefix, 'sitemap-index.xml'), mergedOptions.host).toString();
   } else {
     try {
       new URL(mergedOptions.sitemap)
     } catch {
-      mergedOptions.sitemap = new URL(mergedOptions.sitemap, mergedOptions.host).toString()
+      mergedOptions.sitemap = new URL(mergedOptions.sitemap.startsWith(pathPrefix) ? mergedOptions.sitemap : path.posix.join(pathPrefix, mergedOptions.sitemap), mergedOptions.host).toString()
     }
   }
 

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -72,7 +72,7 @@ export async function onPostBuild({ graphql, pathPrefix = "" }, pluginOptions) {
     !Object.prototype.hasOwnProperty.call(mergedOptions, 'sitemap')
   ) {
 
-    mergedOptions.sitemap = new URL(path.posix.join(pathPrefix, 'sitemap-index.xml'), mergedOptions.host).toString();
+    mergedOptions.sitemap = new URL(path.posix.join(pathPrefix, 'sitemap', 'sitemap-index.xml'), mergedOptions.host).toString();
   } else {
     try {
       new URL(mergedOptions.sitemap)

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -1,7 +1,6 @@
 import fs from 'fs';
 import robotsTxt from 'generate-robotstxt';
 import path from 'path';
-import url from 'url';
 
 const publicPath = './public';
 const defaultEnv = 'development';
@@ -58,8 +57,7 @@ export async function onPostBuild({ graphql }, pluginOptions) {
   const mergedOptions = { ...defaultOptions, ...userOptions };
 
   if (
-    !Object.prototype.hasOwnProperty.call(mergedOptions, 'host') ||
-    !Object.prototype.hasOwnProperty.call(mergedOptions,'sitemap')
+    !Object.prototype.hasOwnProperty.call(mergedOptions, 'host')
   ) {
     const {
       site: {
@@ -68,8 +66,20 @@ export async function onPostBuild({ graphql }, pluginOptions) {
     } = await runQuery(graphql, mergedOptions.query);
 
     mergedOptions.host = siteUrl;
-    mergedOptions.sitemap = url.resolve(siteUrl, 'sitemap.xml');
   }
+
+  if (
+    !Object.prototype.hasOwnProperty.call(mergedOptions, 'sitemap')
+  ) {
+    mergedOptions.sitemap = new URL('sitemap-index.xml', mergedOptions.host).toString();
+  } else {
+    try {
+      new URL(mergedOptions.sitemap)
+    } catch {
+      mergedOptions.sitemap = new URL(mergedOptions.sitemap, mergedOptions.host).toString()
+    }
+  }
+
 
   const { policy, sitemap, host, output, configFile } = mergedOptions;
 

--- a/test/__snapshots__/gatsby-node.test.js.snap
+++ b/test/__snapshots__/gatsby-node.test.js.snap
@@ -19,7 +19,7 @@ Host: https://www.test.com
 exports[`onPostBuild should generate \`robots.txt\` using \`graphql\` options 1`] = `
 "User-agent: *
 Allow: /
-Sitemap: https://www.test.com/sitemap-index.xml
+Sitemap: https://www.test.com/sitemap/sitemap-index.xml
 Host: https://www.test.com
 "
 `;

--- a/test/__snapshots__/gatsby-node.test.js.snap
+++ b/test/__snapshots__/gatsby-node.test.js.snap
@@ -19,7 +19,7 @@ Host: https://www.test.com
 exports[`onPostBuild should generate \`robots.txt\` using \`graphql\` options 1`] = `
 "User-agent: *
 Allow: /
-Sitemap: https://www.test.com/sitemap.xml
+Sitemap: https://www.test.com/sitemap-index.xml
 Host: https://www.test.com
 "
 `;

--- a/test/gatsby-node.test.js
+++ b/test/gatsby-node.test.js
@@ -188,4 +188,63 @@ describe('onPostBuild', () => {
 
     expect(readContent(output)).toContain('Sitemap: https://www.test.com/sitemap-test-relative.xml');
   })
+
+  it(`should add pathPrefix to defaults`, async () => {
+    const output = './robots-sitemap-prefix.txt';
+    const pathPrefix = '/prefix'
+
+    await onPostBuild(
+      {
+        graphql() {
+          return Promise.resolve({ data: graphqlOptions });
+        },
+        pathPrefix
+      },
+      {
+        output,
+      }
+    );
+
+    expect(readContent(output)).toContain('Sitemap: https://www.test.com/prefix/sitemap-index.xml');
+  })
+
+  it(`should add pathPrefix to provided sitemap`, async () => {
+    const output = './robots-sitemap-prefix-provided.txt';
+    const pathPrefix = '/prefix'
+
+    await onPostBuild(
+      {
+        graphql() {
+          return Promise.resolve({ data: graphqlOptions });
+        },
+        pathPrefix
+      },
+      {
+        output,
+        sitemap: 'sitemap.xml'
+      }
+    );
+
+    expect(readContent(output)).toContain('Sitemap: https://www.test.com/prefix/sitemap.xml');
+  })
+
+  it(`should not add pathPrefix if provided sitemap alread has prefix`, async () => {
+    const output = './robots-sitemap-prefix-provided.txt';
+    const pathPrefix = '/prefix'
+
+    await onPostBuild(
+      {
+        graphql() {
+          return Promise.resolve({ data: graphqlOptions });
+        },
+        pathPrefix
+      },
+      {
+        output,
+        sitemap: '/prefix/sitemap.xml'
+      }
+    );
+
+    expect(readContent(output)).toContain('Sitemap: https://www.test.com/prefix/sitemap.xml');
+  })
 });

--- a/test/gatsby-node.test.js
+++ b/test/gatsby-node.test.js
@@ -205,7 +205,7 @@ describe('onPostBuild', () => {
       }
     );
 
-    expect(readContent(output)).toContain('Sitemap: https://www.test.com/prefix/sitemap-index.xml');
+    expect(readContent(output)).toContain('Sitemap: https://www.test.com/prefix/sitemap/sitemap-index.xml');
   })
 
   it(`should add pathPrefix to provided sitemap`, async () => {

--- a/test/gatsby-node.test.js
+++ b/test/gatsby-node.test.js
@@ -148,4 +148,44 @@ describe('onPostBuild', () => {
 
     expect(readContent(output)).toMatchSnapshot();
   });
+
+  it(`should set sitemap separate from host`, async () => {
+    const output = './robots-sitemap.txt';
+
+    await onPostBuild(
+      {
+        graphql() {
+          return Promise.resolve({ data: graphqlOptions });
+        }
+      },
+      {
+        sitemap: 'https://www.test.com/sitemap-test.xml',
+        output,
+        resolveEnv: () => 'custom',
+        env: { custom: { policy: [{ userAgent: '*', disallow: ['/'] }] } }
+      }
+    );
+
+    expect(readContent(output)).toContain('Sitemap: https://www.test.com/sitemap-test.xml');
+  })
+
+  it(`should set sitemap using host if not absolute`, async () => {
+    const output = './robots-sitemap-relative.txt';
+
+    await onPostBuild(
+      {
+        graphql() {
+          return Promise.resolve({ data: graphqlOptions });
+        }
+      },
+      {
+        sitemap: 'sitemap-test-relative.xml',
+        output,
+        resolveEnv: () => 'custom',
+        env: { custom: { policy: [{ userAgent: '*', disallow: ['/'] }] } }
+      }
+    );
+
+    expect(readContent(output)).toContain('Sitemap: https://www.test.com/sitemap-test-relative.xml');
+  })
 });


### PR DESCRIPTION
1. I have fixed a couple small bugs. As noted in #438 the default sitemap name has changed to (`sitemap-index.xml`) though I am trying to revert the default path change from `/sitemap` to `/` in https://github.com/gatsbyjs/gatsby/pull/31184. If this change probably requires a major version bump as it would be breaking. 

2. Because of the above change in `gatsby-plugin-sitemap` I tried to set the `sitemap` option on my site and it would not change from the default. Reading the code I realized there was a bug caused by the [`if` statement](https://github.com/moonmeister/gatsby-plugin-robots-txt/blob/5dbfe2d9b290dc9dca50b60f6e2c84f2345588e0/src/gatsby-node.js#L60-L63) I've fixed this so the custom sitemap path can be set without declaring the host as well. 

3. I removed the dependency on nodes old `url` package to make this more compatible with modern node as well. 

4. I added logic to allow the custom sitemap to be a relative path and prefix the host.

5.  I've put in logic to correctly handle Gatsby's `pathPrefix` feature. 




If you'd like me to split any of this up into smaller PRS or remove anything let me know. Thanks.


Fixes #438 