### PR TITLE
Default value of sitemap option is not correct

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This plugin uses [`generate-robotstxt`](https://github.com/itgalaxy/generate-rob
 |     Name     |    Type    |                Default                |                                  Description                                   |
 | :----------: | :--------: | :-----------------------------------: | :----------------------------------------------------------------------------: |
 |    `host`    |  `String`  |       `${siteMetadata.siteUrl}`       |                               Host of your site                                |
-|  `sitemap`   |  `String` / `String[]`  | `${siteMetadata.siteUrl}/sitemap.xml` |                             Path(s) to `sitemap.xml`                              |
+|  `sitemap`   |  `String` / `String[]`  | `${siteMetadata.siteUrl}/sitemap/sitemap-index.xml` |                             Path(s) to `sitemap.xml`                              |
 |   `policy`   | `Policy[]` |                 `[]`                  | List of [`Policy`](https://github.com/itgalaxy/generate-robotstxt#usage) rules |
 | `configFile` |  `String`  |              `undefined`              |                          Path to external config file                          |
 |   `output`   |  `String`  |             `/robots.txt`             |                     Path where to create the `robots.txt`                      |


### PR DESCRIPTION
The current documentation explains that the default value of the sitemap option is `sitemap.xml` whereas in the code it is written `sitemap/sitemap-index.xml` (see here https://github.com/mdreizin/gatsby-plugin-robots-txt/blob/e04abbc660c611d927148840420395a93a6afe91/src/gatsby-node.js#L75).

This pull request corrects this documentation error.