### PR TITLE
Fixes mdreizin/gatsby-plugin-robots-txt#451

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -56,31 +56,34 @@ export async function onPostBuild({ graphql, pathPrefix = "" }, pluginOptions) {
   const userOptions = getOptions(pluginOptions);
   const mergedOptions = { ...defaultOptions, ...userOptions };
 
-  if (
-    !Object.prototype.hasOwnProperty.call(mergedOptions, 'host')
-  ) {
-    const {
-      site: {
-        siteMetadata: { siteUrl }
-      }
-    } = await runQuery(graphql, mergedOptions.query);
-
-    mergedOptions.host = siteUrl;
-  }
-
-  if (
-    !Object.prototype.hasOwnProperty.call(mergedOptions, 'sitemap')
-  ) {
-
-    mergedOptions.sitemap = new URL(path.posix.join(pathPrefix, 'sitemap', 'sitemap-index.xml'), mergedOptions.host).toString();
-  } else {
-    try {
-      new URL(mergedOptions.sitemap)
-    } catch {
-      mergedOptions.sitemap = new URL(mergedOptions.sitemap.startsWith(pathPrefix) ? mergedOptions.sitemap : path.posix.join(pathPrefix, mergedOptions.sitemap), mergedOptions.host).toString()
+  if(mergedOptions.host !== null) {
+    if (
+      !Object.prototype.hasOwnProperty.call(mergedOptions, 'host')
+    ) {
+      const {
+        site: {
+          siteMetadata: { siteUrl }
+        }
+      } = await runQuery(graphql, mergedOptions.query);
+  
+      mergedOptions.host = siteUrl;
     }
   }
 
+  if(mergedOptions.sitemap !== null) {
+    if (
+      !Object.prototype.hasOwnProperty.call(mergedOptions, 'sitemap')
+    ) {
+  
+      mergedOptions.sitemap = new URL(path.posix.join(pathPrefix, 'sitemap', 'sitemap-index.xml'), mergedOptions.host).toString();
+    } else {
+      try {
+        new URL(mergedOptions.sitemap)
+      } catch {
+        mergedOptions.sitemap = new URL(mergedOptions.sitemap.startsWith(pathPrefix) ? mergedOptions.sitemap : path.posix.join(pathPrefix, mergedOptions.sitemap), mergedOptions.host).toString()
+      }
+    }
+  }
 
   const { policy, sitemap, host, output, configFile } = mergedOptions;
 

--- a/test/__snapshots__/gatsby-node.test.js.snap
+++ b/test/__snapshots__/gatsby-node.test.js.snap
@@ -31,3 +31,17 @@ Sitemap: https://www.test.com/sitemap.xml
 Host: https://www.test.com
 "
 `;
+
+exports[`onPostBuild should generate a \`robots.txt\` without a host property 1`] = `
+"User-agent: *
+Allow: /
+Sitemap: https://www.test.com/sitemap.xml
+"
+`;
+
+exports[`onPostBuild should generate a \`robots.txt\` without a sitemap property 1`] = `
+"User-agent: *
+Allow: /
+Host: https://www.test.com
+"
+`;

--- a/test/gatsby-node.test.js
+++ b/test/gatsby-node.test.js
@@ -62,6 +62,42 @@ describe('onPostBuild', () => {
     expect(readContent(output)).toMatchSnapshot();
   });
 
+  it('should generate a `robots.txt` without a host property', async () => {
+    const output = './robots-host-null.txt';
+
+    await onPostBuild(
+      {
+        graphql() { 
+          return Promise.resolve({ data: {} }) 
+        }
+      }, 
+      {
+        host: null,
+        sitemap: 'https://www.test.com/sitemap.xml',
+        output
+      })
+
+      expect(readContent(output)).toMatchSnapshot();
+  })
+
+  it('should generate a `robots.txt` without a sitemap property', async () => {
+    const output = './robots-sitemap-null.txt';
+
+    await onPostBuild(
+      {
+        graphql() { 
+          return Promise.resolve({ data: {} }) 
+        }
+      }, 
+      {
+        host: 'https://www.test.com',
+        sitemap: null,
+        output
+      })
+
+      expect(readContent(output)).toMatchSnapshot();
+  })
+
   it('should not generate `robots.txt` in case of `graphql` errors', async () => {
     const output = './robots-graphql-err.txt';
 


### PR DESCRIPTION
This should hopefully resolve the issue in #451 where you are not able to pass through `null` for the sitemap and host properties. 

Let me know if this needs any changes, happy to spend some more time on it if required.