### PR TITLE
docs(README): Add note that sitemap xml files is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ This plugin uses [`generate-robotstxt`](https://github.com/itgalaxy/generate-rob
 | `configFile` |  `String`  |              `undefined`              |                          Path to external config file                          |
 |   `output`   |  `String`  |             `/robots.txt`             |                     Path where to create the `robots.txt`                      |
 
+Please note that for proper `robots.txt` file generation sitemap xml file defined as `sitemap` has
+to be present.
+You can use official [Gatsby plugin `gatsby-plugin-sitemap`](https://www.gatsbyjs.com/plugins/gatsby-plugin-sitemap)
+to generate sitemap files automatically during the production website build.
+
 `gatsby-config.js`
 
 ```js


### PR DESCRIPTION
The fact that this plugin won't create `sitemap.xml` file(s) wasn't clear to me. I thought that this is the complete solution and originally wasn't aware of `gatsby-plugin-sitemap` plugin creating sitemap xml files for gatsby sites.
That plugin seems to be required to get the most of this one. Please correct me if I'm wrong.

Suggest to add some kind of clarification into `README` but completely open to better suggestions and further discussion.

Thank you